### PR TITLE
lodash to >=4.17.20

### DIFF
--- a/docs/latest/package.json
+++ b/docs/latest/package.json
@@ -39,6 +39,7 @@
     "gitbook-plugin-versions": "^2.1.4"
   },
   "devDependencies": {
-    "gitbook-cli": "^2.3.2"
+    "gitbook-cli": "^2.3.2",
+    "lodash": "^4.17.20"
   }
 }

--- a/docs/latest/yarn.lock
+++ b/docs/latest/yarn.lock
@@ -1672,6 +1672,11 @@ lodash@^4.17.11:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.20:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 lowercase-keys@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"

--- a/docs/v1/package.json
+++ b/docs/v1/package.json
@@ -39,6 +39,7 @@
     "gitbook-plugin-versions": "^2.1.4"
   },
   "devDependencies": {
-    "gitbook-cli": "^2.3.2"
+    "gitbook-cli": "^2.3.2",
+    "lodash": "^4.17.20"
   }
 }


### PR DESCRIPTION
[SNYK-JS-LODASH-567746](https://app.snyk.io/vuln/SNYK-JS-LODASH-567746)

```
Introduced through gitbook-cli@2.3.2
Fixed in lodash@4.17.20

Introduced through: ohif-viewer-latest-docs@2.0.0 › gitbook-cli@2.3.2 › lodash@4.17.4
Introduced through: ohif-viewer-latest-docs@2.0.0 › gitbook-cli@2.3.2 › npmi@1.0.1 › npm@2.15.12 › request@2.74.0 › form-data@1.0.1 › async@2.6.2 › lodash@4.17.11
```