### PR TITLE
jsonpointer 4.1.0

### DIFF
--- a/docs/latest/package.json
+++ b/docs/latest/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "gitbook-cli": "^2.3.2",
-    "lodash": "^4.17.20"
+    "lodash": "^4.17.20",
+    "jsonpointer": "^4.1.0"
   }
 }

--- a/docs/latest/yarn.lock
+++ b/docs/latest/yarn.lock
@@ -1520,6 +1520,11 @@ jsonpointer@^4.0.0:
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
   integrity sha1-T9kss04OnbPInIYi7PUfm5eMbLk=
 
+jsonpointer@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.1.0.tgz#501fb89986a2389765ba09e6053299ceb4f2c2cc"
+  integrity sha512-CXcRvMyTlnR53xMcKnuMzfCA5i/nfblTnnr74CZb6C4vG39eu6w51t7nKmU5MfLfbTgGItliNyjO/ciNPDqClg==
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"


### PR DESCRIPTION


### Dependency updates
- `gitbook-cli` has a `jsonpointer` sub-dependency and we need `jsonpointer` >= 4.1.0
