### PR TITLE
Handle missing ReferencedInstanceSequence

### DIFF
--- a/platform/core/src/studies/services/wado/getReferencedSeriesSequence.js
+++ b/platform/core/src/studies/services/wado/getReferencedSeriesSequence.js
@@ -21,16 +21,18 @@ const getReferencedSeriesSequence = instance => {
       const referencedInstanceSequenceRaw = referencedSeries['0008114A'];
       const referencedInstanceSequence = [];
 
-      referencedInstanceSequenceRaw.Value.forEach(referencedInstance => {
-        referencedInstanceSequence.push({
-          referencedSOPClassUID: DICOMWeb.getString(
-            referencedInstance['00081150']
-          ),
-          referencedSOPInstanceUID: DICOMWeb.getString(
-            referencedInstance['00081155']
-          ),
+      if (referencedInstanceSequenceRaw) {
+        referencedInstanceSequenceRaw.Value.forEach(referencedInstance => {
+          referencedInstanceSequence.push({
+            referencedSOPClassUID: DICOMWeb.getString(
+              referencedInstance['00081150']
+            ),
+            referencedSOPInstanceUID: DICOMWeb.getString(
+              referencedInstance['00081155']
+            ),
+          });
         });
-      });
+      }
 
       referencedSeriesSequence.push({
         referencedSeriesInstanceUID,


### PR DESCRIPTION
The viewer could not load the study `2.16.840.1.114274.1818.50277172253048277328499478501581069995`

`Cannot read properties of undefined (reading 'Value')` at `referencedInstanceSequenceRaw.Value.forEach...` because the file does not have attribute "0008,114A" (`ReferencedInstanceSequence`) which is optional according to the spec: https://dicom.innolitics.com/ciods/rt-plan/general-reference/0008114a.

### Bug Fixes
- Handle missing "0008,114A" ReferencedInstanceSequence attributes
