### PR TITLE
Add Amazon Liniux base image changes to Dockerfile from `v3.8.0`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: git@github.com:Yelp/detect-secrets
+    rev: v0.13.1
+    hooks:
+      - id: detect-secrets
+        args: ["--baseline", ".secrets.baseline"]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,439 @@
+{
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2025-01-31T20:10:24Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "platform/app/.recipes/Nginx-Dcm4chee/docker-compose-dcm4che.env": [
+      {
+        "hashed_secret": "91ee514191b45f784becb932f3df5a49cf823f8f",
+        "is_verified": false,
+        "line_number": 4,
+        "type": "Secret Keyword"
+      }
+    ],
+    "platform/app/.recipes/OpenResty-Orthanc-Keycloak/config/nginx.conf": [
+      {
+        "hashed_secret": "16414de0142348bad1291edd29e55ca2c5da3f13",
+        "is_verified": false,
+        "line_number": 82,
+        "type": "Secret Keyword"
+      }
+    ],
+    "platform/app/.recipes/OpenResty-Orthanc-Keycloak/config/ohif-keycloak-realm.json": [
+      {
+        "hashed_secret": "16414de0142348bad1291edd29e55ca2c5da3f13",
+        "is_verified": false,
+        "line_number": 481,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "e9b63f81d259320fd403a4276a2eb8d0586774d1",
+        "is_verified": false,
+        "line_number": 638,
+        "type": "Secret Keyword"
+      }
+    ],
+    "platform/app/.recipes/OpenResty-Orthanc-Keycloak/volumes/keycloak-themes/ohif/login/resources/css/styles.css": [
+      {
+        "hashed_secret": "fbc5881426baf05f182f0473d6ccddce906092b3",
+        "is_verified": false,
+        "line_number": 67,
+        "type": "Secret Keyword"
+      }
+    ],
+    "platform/app/public/html-templates/rollbar.html": [
+      {
+        "hashed_secret": "75b845f1c4e4deab021ebd9436d007e90205deb3",
+        "is_verified": false,
+        "line_number": 230,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "platform/app/public/oidc-client.min.js": [
+      {
+        "hashed_secret": "1d278d3c888d1a2fa7eed622bfc02927ce4049af",
+        "is_verified": false,
+        "line_number": 5121,
+        "type": "Base64 High Entropy String"
+      },
+      {
+        "hashed_secret": "ee7461cf99f5ba4a728957e70fa9a5e1cfc7a3a3",
+        "is_verified": false,
+        "line_number": 7349,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "13e1293a66d5a3a49d53617a98a370a0527e4e27",
+        "is_verified": false,
+        "line_number": 7350,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "2e20a83a1683e98d7faa6d1db5eb944ba846c335",
+        "is_verified": false,
+        "line_number": 7894,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "791aeaadbba0dc391d54248e7fb023fa02740307",
+        "is_verified": false,
+        "line_number": 8216,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7bf34b225e80d22938e28c619ab4b002dd7e7b29",
+        "is_verified": false,
+        "line_number": 8268,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "39b3e9966134e9725df88062f0e2bf10b952c076",
+        "is_verified": false,
+        "line_number": 8269,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "10684db52c27b4692a4ee51ef75a1d5234069c53",
+        "is_verified": false,
+        "line_number": 8271,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "7c9ddb05834fa9e6c06ef9d948eb8e1a73881031",
+        "is_verified": false,
+        "line_number": 8272,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "02dea585f59babe05225954c8d1fdec196a1baec",
+        "is_verified": false,
+        "line_number": 8285,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "07d36c201d5f903272b769508b29de6bfc474556",
+        "is_verified": false,
+        "line_number": 8286,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "6b74fbdc313f800d523b66be1232d9b4e41b9977",
+        "is_verified": false,
+        "line_number": 8296,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f6de6313ace4093d98c0aea3ddb1a7a733b058e6",
+        "is_verified": false,
+        "line_number": 8299,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "332e2126e121cf2048b5a1903f864df144047773",
+        "is_verified": false,
+        "line_number": 8300,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "6c9aafdcceb33bbcfd232f40afdb3298eb2c8b03",
+        "is_verified": false,
+        "line_number": 8313,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f8692127a363c0b90301c1f9b9713a130eb23685",
+        "is_verified": false,
+        "line_number": 8314,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "df173adb55673098ee5082e74d50e78dedd5cb60",
+        "is_verified": false,
+        "line_number": 8322,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "32358b0b40f22e5aa4d70e9d0af6cf156840ee38",
+        "is_verified": false,
+        "line_number": 8325,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "46798dc6618143b34916eb0e8b3e653b368f7469",
+        "is_verified": false,
+        "line_number": 8326,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "188736fa0029eec343f4a6f4881ec63ecc7c7e8c",
+        "is_verified": false,
+        "line_number": 8334,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "9ed5e5eb0104bf6b3aecf69b389c289b3dca8261",
+        "is_verified": false,
+        "line_number": 8337,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "de3227cfb3b4dcdee04c35b442308cbc451d7424",
+        "is_verified": false,
+        "line_number": 8338,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "a6bd0a3ad636211901f4d216f36f325283d65a18",
+        "is_verified": false,
+        "line_number": 8349,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "74ad6a5ac8a6c93372210cdd119a74082a515c2a",
+        "is_verified": false,
+        "line_number": 8350,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "aadcdc8ac4254184c1a90fa9c7cc0e8a7dad2e25",
+        "is_verified": false,
+        "line_number": 8358,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "fd193a67b4b1b180176f242ae3b8771e2c9fe3f9",
+        "is_verified": false,
+        "line_number": 8359,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "10bf5f5bab05c99283d3d3cd1c3da4ead81b48c5",
+        "is_verified": false,
+        "line_number": 8361,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "df4bff4de4289a6c92aea9d5f068158c89d4ae4b",
+        "is_verified": false,
+        "line_number": 8362,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c579f32498a8e63758e8b88d1657f5ecaebe282b",
+        "is_verified": false,
+        "line_number": 8370,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "abb735bc3c235dd7c37dadaad2e22ab489654e6a",
+        "is_verified": false,
+        "line_number": 8373,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "edce10f49ab5f9e6931d84b93f1684c83befc752",
+        "is_verified": false,
+        "line_number": 8374,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "58b3b73cf9a2c84af3392b462be5b6de7c2b6f58",
+        "is_verified": false,
+        "line_number": 8382,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "c1cd31248395318846b40305139bcc884a1c76b8",
+        "is_verified": false,
+        "line_number": 8385,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "11292b959033b13fcd7274035876ea74f5d665c7",
+        "is_verified": false,
+        "line_number": 8386,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "ccec3989a7361b8becd9b8aacb7c41f3e57cb627",
+        "is_verified": false,
+        "line_number": 8548,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "5ad18dab943e7b2c85b8bc678d46338c5fc5e3bb",
+        "is_verified": false,
+        "line_number": 8554,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "42e56fb6d8eab85124cdae2e089aef0645e85847",
+        "is_verified": false,
+        "line_number": 8559,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "095f82ea020d033be940bfa8ccf3ef0ca0924c2f",
+        "is_verified": false,
+        "line_number": 8634,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "0c7772fa0d39d0f13390bdb088ad9a275547bc0b",
+        "is_verified": false,
+        "line_number": 8635,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "f218ef902d68446040d0400ac9f43d5defc9cac3",
+        "is_verified": false,
+        "line_number": 9286,
+        "type": "Hex High Entropy String"
+      },
+      {
+        "hashed_secret": "e1b17fc96a827a312ab28908decdbb7f159f9b06",
+        "is_verified": false,
+        "line_number": 9786,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "platform/core/src/DICOMWeb/getAuthorizationHeader.test.js": [
+      {
+        "hashed_secret": "877ee470d25f0284c6e41ddf17e3587136ce2328",
+        "is_verified": false,
+        "line_number": 43,
+        "type": "Base64 High Entropy String"
+      }
+    ],
+    "platform/docs/docs/deployment/user-account-control.md": [
+      {
+        "hashed_secret": "2e36d56b54db3f434574091bf8d381e8d9fa9b2b",
+        "is_verified": false,
+        "line_number": 89,
+        "type": "Secret Keyword"
+      }
+    ],
+    "platform/docs/docs/platform/environment-variables.md": [
+      {
+        "hashed_secret": "b77cb8f8d63b03a7a8952e58dcb6762c52602284",
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Secret Keyword"
+      }
+    ],
+    "platform/docs/docusaurus.config.js": [
+      {
+        "hashed_secret": "2844e02f70cdaf2c0dbaf7b347cf8054d2c91c42",
+        "is_verified": false,
+        "line_number": 281,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "2844e02f70cdaf2c0dbaf7b347cf8054d2c91c42",
+        "is_verified": false,
+        "line_number": 281,
+        "type": "Hex High Entropy String"
+      }
+    ],
+    "platform/docs/versioned_docs/version-1.0-deprecated/OHIF-Viewer/environment-installations.md": [
+      {
+        "hashed_secret": "91ee514191b45f784becb932f3df5a49cf823f8f",
+        "is_verified": false,
+        "line_number": 149,
+        "type": "Secret Keyword"
+      }
+    ],
+    "platform/docs/versioned_docs/version-1.0-deprecated/connecting-to-image-archives/dcm4chee-with-docker.md": [
+      {
+        "hashed_secret": "2b5ac465ddfe67e16fb9e9c21187122b7fbb53a7",
+        "is_verified": false,
+        "line_number": 39,
+        "type": "Secret Keyword"
+      }
+    ],
+    "platform/docs/versioned_docs/version-2.0-deprecated/deployment/recipes/user-account-control.md": [
+      {
+        "hashed_secret": "2e36d56b54db3f434574091bf8d381e8d9fa9b2b",
+        "is_verified": false,
+        "line_number": 89,
+        "type": "Secret Keyword"
+      }
+    ],
+    "platform/docs/versioned_docs/version-2.0-deprecated/viewer/environment-variables.md": [
+      {
+        "hashed_secret": "b77cb8f8d63b03a7a8952e58dcb6762c52602284",
+        "is_verified": false,
+        "line_number": 20,
+        "type": "Secret Keyword"
+      }
+    ],
+    "version.json": [
+      {
+        "hashed_secret": "5b4c7af11a4b79f1bfb9017d3fd31721277105f2",
+        "is_verified": false,
+        "line_number": 3,
+        "type": "Hex High Entropy String"
+      }
+    ]
+  },
+  "version": "0.13.1",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,13 @@
 # This dockerfile has two stages:
 #
 # 1. Building the React application for production
-# 2. Setting up our Nginx (Alpine Linux) image w/ step one's output
+# 2. Setting up our Nginx (Amazon Linux) image w/ step one's output
 #
 
 
 # Stage 1: Build the application
 # docker build -t ohif/viewer:latest .
-FROM node:18.16.1-slim as json-copier
+FROM 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/amazonlinux-base:master AS json-copier
 
 RUN mkdir /usr/src/app
 WORKDIR /usr/src/app
@@ -37,8 +37,15 @@ COPY platform /usr/src/app/platform
 #RUN find platform \! -name "package.json" -mindepth 2 -maxdepth 2 -print | xargs rm -rf
 
 # Copy Files
-FROM node:18.16.1-slim as builder
-RUN apt-get update && apt-get install -y build-essential python3
+FROM 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/amazonlinux-base:master AS builder
+
+RUN yum update -y && \
+  yum groupinstall "Development Tools" -y && \
+  yum install -y gcc-c++ make && \
+  curl -sL https://rpm.nodesource.com/setup_18.x | bash - && \
+  yum install -y nodejs-18.16.1 && \
+  npm install -g yarn
+
 RUN mkdir /usr/src/app
 WORKDIR /usr/src/app
 
@@ -53,28 +60,34 @@ COPY . .
 # To restore workspaces symlinks
 RUN yarn install --frozen-lockfile --verbose
 
-ENV PATH /usr/src/app/node_modules/.bin:$PATH
-ENV QUICK_BUILD true
-ENV PUBLIC_URL /ohif-viewer/
+ENV PATH=/usr/src/app/node_modules/.bin:$PATH
+ENV QUICK_BUILD=true
+ENV PUBLIC_URL=/ohif-viewer/
 # ENV GENERATE_SOURCEMAP=false
 # ENV REACT_APP_CONFIG=config/default.js
 
 RUN yarn run build
 
 # Stage 3: Bundle the built application into a Docker container
-# which runs Nginx using Alpine Linux
-FROM nginxinc/nginx-unprivileged:1.25-alpine as final
+# which runs Nginx built on top of Amazon Linux
+
+FROM quay.io/cdis/python-nginx-al:master AS final
 #RUN apk add --no-cache bash
 ENV PORT=8080
-RUN rm /etc/nginx/conf.d/default.conf
-USER nginx
-COPY --chown=nginx:nginx .docker/Viewer-v3.x /usr/src
+USER gen3
+COPY --chown=gen3:gen3 .docker/Viewer-v3.x /usr/src
 RUN chmod 777 /usr/src/entrypoint.sh
 COPY --from=builder /usr/src/app/platform/app/dist /usr/share/nginx/html
 # In entrypoint.sh, app-config.js might be overwritten, so chmod it to be writeable.
 # The nginx user cannot chmod it, so change to root.
 USER root
-RUN chmod 666 /usr/share/nginx/html/app-config.js
-USER nginx
+RUN chmod 666 /usr/share/nginx/html/app-config.js && \
+  chmod 664 /etc/nginx/* && \
+  chmod 775 /etc/nginx/conf.d && \
+  chown -R gen3:root /etc/nginx && \
+  yum install -y gettext && \
+  yum clean all
+
+USER gen3
 ENTRYPOINT ["/usr/src/entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
##  Improvements

* Update to use new Amazon Linux base image and use the same structure as our other python services.
* Utilizing "gen3" user instead of "nginx" user to work with the uc-cdis's nginx-al base image
** Note: These updates are made on top of `master-gen3` branch which is based on OHIF:v3.8.0
