### PR TITLE
Adding a null check in `addRetrieveBulkDataNaturalized`

### DIFF
--- a/extensions/default/src/DicomWebDataSource/index.js
+++ b/extensions/default/src/DicomWebDataSource/index.js
@@ -387,6 +387,9 @@ function createDicomWebApi(dicomWebConfig, servicesManager) {
        * This is done recursively, for sub-sequences.
        */
       const addRetrieveBulkDataNaturalized = (naturalized, instance = naturalized) => {
+        if (!naturalized) {
+          return naturalized;
+        }
         for (const key of Object.keys(naturalized)) {
           const value = naturalized[key];
 


### PR DESCRIPTION
Link to Jira ticket : [MIDRC-908](https://ctds-planx.atlassian.net/browse/MIDRC-908)

## Bug Fixes:
* Fix: Missing null check which prevented some of the DICOM images from loading when certain elements in the nested structure coming from the backend have any `null` values.



PS: Made a [PR](https://github.com/OHIF/Viewers/pull/4866) to upstream OHIF/Viewers proposing this change. Waiting for review. 

[MIDRC-908]: https://ctds-planx.atlassian.net/browse/MIDRC-908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ